### PR TITLE
Openownership work needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -15,3 +15,47 @@ Include this extension in conf.py::
 Write ``jsonschema`` directive into reST file where you want to import schema::
 
     .. jsonschema:: path/to/your.json
+
+Option - pointer
+----------------
+
+To be documented
+
+
+Option - include
+-----------------
+
+
+To be documented
+
+
+Option - collapse
+-----------------
+
+
+To be documented
+
+Option - externallinks
+----------------------
+
+After some entries, it will generate a "See" link.
+
+This will happen automatically every time there is a JSON reference.
+
+You can also tell it to happen explicitly on certain nodes, by use of the externallinks option.
+
+        :externallinks: {"share":{"url":"#share","text":"Share"},"unspecified/reason":{"url":"https://www.google.com/","text":"Google"}}
+
+The first key is the name of the property to add the link to. Note you can do paths.
+
+The url is the url to link to, and the text is what is shown on in the link, after "See".
+
+
+Option - nocrossref
+-------------------
+
+After some entries, it will generate a "See" link.
+
+This will happen automatically every time there is a JSON reference.
+
+If you do not want this behavior, pass this flag.

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -17,13 +17,8 @@ from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 from docutils.utils import new_document
 from recommonmark.parser import CommonMarkParser
-
-if sys.version_info < (2, 7):
-    import simplejson as json
-    from ordereddict import OrderedDict
-else:
-    import json
-    from collections import OrderedDict
+import json
+from collections import OrderedDict
 
 
 class JSONSchemaDirective(Directive):

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -25,11 +25,6 @@ else:
     from collections import OrderedDict
 
 
-class CustomJsonrefLoader(jsonref.JsonLoader):
-    def get_remote_json(self, uri, **kwargs):
-        return {}
-
-
 class JSONSchemaDirective(Directive):
     has_content = True
     required_arguments = 1
@@ -206,12 +201,12 @@ def simplify(obj):
 class JSONSchema(object):
     @classmethod
     def load(cls, reader):
-        obj = jsonref.load(reader, object_pairs_hook=OrderedDict, loader=CustomJsonrefLoader())
+        obj = jsonref.load(reader, object_pairs_hook=OrderedDict)
         return cls.instantiate(None, obj)
 
     @classmethod
     def loads(cls, string):
-        obj = jsonref.loads(string, object_pairs_hook=OrderedDict, loader=CustomJsonrefLoader())
+        obj = jsonref.loads(string, object_pairs_hook=OrderedDict)
         return cls.instantiate(None, obj)
 
     @classmethod

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -8,7 +8,6 @@
 """
 import io
 import os
-import sys
 import jsonref
 from pathlib import Path
 from jsonpointer import resolve_pointer

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -10,6 +10,7 @@ import io
 import os
 import sys
 import jsonref
+from pathlib import Path
 from jsonpointer import resolve_pointer
 from six import string_types
 from docutils import nodes
@@ -200,8 +201,8 @@ def simplify(obj):
 
 class JSONSchema(object):
     @classmethod
-    def load(cls, reader):
-        obj = jsonref.load(reader, object_pairs_hook=OrderedDict)
+    def load(cls, reader, base_uri=None):
+        obj = jsonref.load(reader, object_pairs_hook=OrderedDict, base_uri=base_uri)
         return cls.instantiate(None, obj)
 
     @classmethod
@@ -212,7 +213,7 @@ class JSONSchema(object):
     @classmethod
     def loadfromfile(cls, filename):
         with io.open(filename, 'rt', encoding='utf-8') as reader:
-            return cls.load(reader)
+            return cls.load(reader, base_uri=Path(os.path.realpath(filename)).as_uri())
 
     @classmethod
     def instantiate(cls, name, obj, required=False, parent=None, rollup=True):

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -213,7 +213,7 @@ class TestJsonSchema(unittest.TestCase):
         }"""
         schema = JSONSchema.loads(data)
         self.assertEqual(schema.validations,
-                         ['It must be equal to one of the elements ' +
+                         ['It must be equal to one of the elements ' +  # noqa
                           'in ["string", {"type": "object", "maxProperties": 3}, null, 42]'])
 
 # Validation for any instance type

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36
+envlist=py34,py35,py36
 
 [testenv]
 deps=


### PR DESCRIPTION
There are several things happening here:

1) Remove the code that disabled get_remote_json. Now I'm not entirely sure why this was disabled in  the first place - maybe just enabling it again will cause other issues?

2) Pass base_uri to jsonref.load - this is needed or it can't load relative files.

3) Remove Python 2 support. If we really want this, then I've added pathlib.Path which is 3 only.

Discussed with @kindly on call but now put as PR for all to discuss.

This is related to https://github.com/openownership/data-standard-sphinx-theme/issues/4