### PR TITLE
setup: Add missing requirement (docutils) and remove unused requirement (sphinx)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,6 @@ from setuptools import setup, find_packages
 
 long_desc = open('README.rst').read()
 
-requires = [
-    'Sphinx>=0.6',
-    'jsonref',
-    'jsonpointer',
-    'recommonmark',
-]
-
 setup(
     name='sphinxcontrib-opendataservices-jsonschema',
     version='0.1.0',
@@ -41,6 +34,11 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=requires,
+    install_requires=[
+        'docutils',
+        'jsonref',
+        'jsonpointer',
+        'recommonmark',
+    ],
     namespace_packages=['sphinxcontrib'],
 )


### PR DESCRIPTION
Please make a release after reviewing this and #27. https://github.com/OpenDataServices/sphinxcontrib-opendataservices/pull/26 is failing because `six` is missing.

You might also like to use a GitHub Actions workflow to simplify releases. See for example https://ocp-software-handbook.readthedocs.io/en/latest/python/packages.html#release-process