### PR TITLE
requirements: Remove myst-parser duplicate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'test': [
             'flake8',
             'lxml',
-            'myst-parser',
             'pytest',
         ],
     },


### PR DESCRIPTION
This duplication was just caused by the order of PRs.