### PR TITLE
Allow cells to be referenced

### DIFF
--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -32,6 +32,7 @@ class JSONSchemaDirective(Directive):
         'collapse': directives.unchanged,
         'pointer': directives.unchanged,
         'nocrossref': directives.flag,
+        'addtargets': directives.flag,
     }
     # Add a rollup option here
 
@@ -129,8 +130,10 @@ class JSONSchemaDirective(Directive):
             self.arguments[0].split('/')[-1],
             self.options.get('pointer', ''),
             prop.name)
-        cell = nodes.entry('', nodes.target(ids=[anchor], names=[anchor]), nodes.literal('', nodes.Text(prop.name)),
-                           morecols=1)
+        target = nodes.target(ids=[anchor], names=[anchor])
+        if 'addtargets' in self.options:
+            self.state.document.note_explicit_target(target)
+        cell = nodes.entry('', target, nodes.literal('', nodes.Text(prop.name)), morecols=1)
         row += cell
         row += self.cell(prop.type)
         row += self.cell(prop.format or '')

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -130,7 +130,7 @@ class JSONSchemaDirective(Directive):
             self.arguments[0].split('/')[-1],
             self.options.get('pointer', ''),
             prop.name)
-        target = nodes.target(ids=[anchor], names=[anchor])
+        target = nodes.target(ids=[anchor], names=[anchor.lower()])
         if 'addtargets' in self.options:
             self.state.document.note_explicit_target(target)
         cell = nodes.entry('', target, nodes.literal('', nodes.Text(prop.name)), morecols=1)


### PR DESCRIPTION
Currently, when using MyST-Parser, you can only reference these cells using `<a href="path/to/file#schema.json,,field">` (i.e. not taking advantage of Sphinx reference resolution), because targets have not been created using `note_explicit_target`.

I've added an `addtargets` directive option to enable target creation. It's not enabled by default, because the directive can be called multiple times on the same or different pages. In practice, you generally want one "authoritative" table to link to for a given JSON Schema path. So, the user indicates which table is authoritative by setting the `addtargets` flag.