### PR TITLE
sphinxcontrib/jsonschema.py: Replace '_' with '-' in links to HTML anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Replace '_' with '-' in HTML anchors https://github.com/OpenDataServices/sphinxcontrib-opendataservices-jsonschema/pull/51
 - Add myst-parser 0.19.0, 1 and 2 support (Changes API in myst-parser we use)
 - Removed Python 3.7 and below support
 

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -185,8 +185,8 @@ class JSONSchemaDirective(Directive):
                 if ref:
                     # just use the name at the end of the ref
                     ref = ref.split('/')[-1]
-                    reference = nodes.reference('', '', nodes.Text(ref), internal=False, refuri='#' + ref.lower(),
-                                                anchorname='')
+                    reference = nodes.reference('', '', nodes.Text(ref), internal=False,
+                                                refuri='#' + nodes.make_id(ref), anchorname='')
                     cell += nodes.paragraph('', nodes.Text('\n\nSee '), reference)
                 if prop.deprecated:
                     cell += nodes.paragraph('', nodes.Text('This property was deprecated in version {}'

--- a/tests/examples/basic.html
+++ b/tests/examples/basic.html
@@ -52,16 +52,20 @@
                         </td>
                     </tr>
                     <tr class="row-even">
-                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,mailAddress"><span class="pre">mailAddress</span></code></td>
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,address"><span class="pre">address</span></code></td>
                         <td colspan="1">
-                            <p>string</p>
+                            <p>object</p>
                         </td>
                         <td colspan="1"></td>
                         <td colspan="1"></td>
                     </tr>
                     <tr class="row-odd">
                         <td colspan="1">
-                            <p>None</p>
+                            <p>Address</p>
+                        </td>
+                        <td colspan="4">
+                            <p>Where this person lives. NOTE: The underscore should become a dash in the anchor name.</p>
+                            <p>See <a class="reference external" href="#address-definition">Address_definition</a></p>
                         </td>
                     </tr>
                     <tr class="row-even">

--- a/tests/examples/basic/subdir/test.json
+++ b/tests/examples/basic/subdir/test.json
@@ -9,7 +9,11 @@
          "maximum" : "80",
          "minimum" : "20"
      },
-     "mailAddress" : "string",
+     "address": {
+       "$ref": "/definitions/Address_definition",
+       "title": "Address",
+       "description": "Where this person lives. NOTE: The underscore should become a dash in the anchor name."
+     },
      "otherContacts" : {
         "type" : "array",
         "default" : "['abc', 'def', 'ghi']",
@@ -18,5 +22,24 @@
         }
      }
   },
- "required": ["otherContacts"]
+ "required": ["otherContacts"],
+ "definitions": {
+   "Address_definition": {
+     "type": "object",
+     "properties": {
+       "address": {
+         "type": "string",
+         "title": "Address Details"
+       },
+       "postcode": {
+         "type": "string",
+         "title": "Postcode"
+       },
+       "country": {
+         "type": "string",
+         "title": "Country"
+       }
+     }
+   }
+  }
 }


### PR DESCRIPTION
Sphinx replaces the `_` character in HTML anchors with `-`, per https://docutils.sourceforge.io/docutils/nodes.py:

>     Docutils identifiers will conform to the regular expression
>     ``[a-z](-?[a-z0-9]+)*``.  For CSS compatibility, identifiers (the "class"
>     and "id" attributes) should have no underscores, colons, or periods.
>     Hyphens may be used.

This PR does the same in the links generated when `nocrossref` isn't specified.

@Bjwebb I'm assuming that you're the right person to review this, but let me know if not!