### PR TITLE
Add myst-parser 0.19.0, 1 and 2 support & Removed Python 3.7 and below support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
-        myst-parser-version: [ '<0.18.0', '>=0.18.0' ]
+        python-version: [  '3.8', '3.9', '3.10', '3.11']
+        myst-parser-version: [ '<0.18.0', '>=0.18.0,<0.19', '>=0.19.0,<1.0', '>=1.0.0,<2', '>=2.0.0,<3']
         jsonref-version: [">1"]
-        exclude:
-          - python-version: '3.6'
-            myst-parser-version: '>=0.18.0'
         include:
           # jsonref 1.0 has a backwards incompatible change - make sure we test just once with an older version of jsonref
           - python-version: '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Add myst-parser 0.19.0, 1 and 2 support (Changes API in myst-parser we use)
+- Removed Python 3.7 and below support
+
 ## [0.5.1] - 2022-12-01
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -34,6 +32,7 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
+    python_requires='>=3.8',
     install_requires=[
         'docutils',
         'jsonref',

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -23,13 +23,13 @@ try:
 except ModuleNotFoundError:
     from myst_parser.config.main import MdParserConfig
     from myst_parser.mdit_to_docutils.base import make_document
-    from myst_parser.mdit_to_docutils.sphinx_ import SphinxRenderer
+    from myst_parser.mdit_to_docutils.sphinx_ import DocutilsRenderer
     from myst_parser.parsers.mdit import create_md_parser
 
     # to_docutils was removed in myst-parser>=0.18.
     def to_docutils(text):
         # Code is similar to MystParser.parse and myst_parser.parsers.docutils_.Parser.parse.
-        parser = create_md_parser(MdParserConfig(), SphinxRenderer)
+        parser = create_md_parser(MdParserConfig(), DocutilsRenderer)
         parser.options["document"] = make_document()
         return parser.render(text)
 

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -1,8 +1,6 @@
 import re
-import sys
 
 import lxml.html
-import myst_parser
 import pytest
 
 from tests import path
@@ -22,10 +20,10 @@ def assert_build(app, status, warning, basename, buildername='html', messages=No
         with open(path(basename, '_build', buildername, 'index.html'), encoding='utf-8') as f:
             element = lxml.html.fromstring(f.read()).xpath('//div[@class="documentwrapper"]')[0]
             actual = lxml.html.tostring(element).decode()
-            # This is required for python 3.7 and myst-parser<0.18.0 support
-            if sys.version_info < (3, 8) or list(map(int, myst_parser.__version__.split("."))) < [0, 18, 0]:
-                # regex must be non-greedy, otherwise you can't put more than one table on a page
-                actual = re.sub(r'<colgroup>.*?</colgroup>', '', actual, flags=re.DOTALL)
+            # Some versions of myst-parser have colgroup, some don't.
+            # Remove from actual to get consistent tests across all versions.
+            # regex must be non-greedy, otherwise you can't put more than one table on a page
+            actual = re.sub(r'<colgroup>.*?</colgroup>', '', actual, flags=re.DOTALL)
 
         with open(path(f'{basename}.html'), encoding='utf-8') as f:
             expected = f.read()


### PR DESCRIPTION


https://github.com/OpenDataServices/sphinxcontrib-opendataservices-jsonschema/pull/52#issuecomment-1697841996 https://github.com/executablebooks/MyST-Parser/issues/768