### PR TITLE
sphinxcontrib/jsonschema.py: Fix include and collapse logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
       matrix:
         python-version: [  '3.8', '3.9', '3.10', '3.11']
         # Removed testing of myst-parser-version<0.18.0
-        myst-parser-version: [ '>=0.18.0,<0.19', '>=0.19.0,<1.0', '>=1.0.0,<2', '>=2.0.0,<3']
+        myst-parser-version: [ '>=0.18.0,<0.19', '>=0.19.0,<1.0', '>=1.0.0,<2', '>=2.0.0,<3', '>=3.0.0,<4']
         jsonref-version: [">1"]
         include:
           # jsonref 1.0 has a backwards incompatible change - make sure we test just once with an older version of jsonref
           - python-version: '3.11'
             jsonref-version: "==0.3"
-            myst-parser-version: '>=0.18.0'
+            myst-parser-version: '>=3.0.0,<4'
     steps:
     - uses: actions/checkout@v2
     - name: Setup python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- include & collapse fix; only work on names that match fully, not just those that start with https://github.com/OpenDataServices/sphinxcontrib-opendataservices-jsonschema/pull/60
+
 ## [0.7.0] - 2024-05-03
 
 ### Changed

--- a/tests/examples/basic-externallinks/conf.py
+++ b/tests/examples/basic-externallinks/conf.py
@@ -1,2 +1,3 @@
 master_doc = 'index'
 extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-externalrefs/conf.py
+++ b/tests/examples/basic-externalrefs/conf.py
@@ -1,2 +1,3 @@
 master_doc = 'index'
 extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-include.html
+++ b/tests/examples/basic-include.html
@@ -1,0 +1,78 @@
+<div class="documentwrapper">
+    <div class="bodywrapper">
+        <div class="body" role="main">
+            <table class="docutils align-default">
+                <thead>
+                    <tr class="row-odd">
+                        <th class="head" colspan="1">
+                            <p>
+                            Title</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>
+                            Description</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>
+                            Type</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>
+                            Format</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>
+                            Required</p>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="row-even">
+                        <td colspan="2">
+                            <code class="docutils literal notranslate" id="test.json,,id">
+                            <span class="pre">
+                            id</span>
+                            </code>
+                        </td>
+                        <td colspan="1">
+                            <p>
+                            string</p>
+                        </td>
+                        <td colspan="1">
+                        </td>
+                        <td colspan="1">
+                        </td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>
+                            None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2">
+                            <code class="docutils literal notranslate" id="test.json,,name/formal">
+                            <span class="pre">
+                            name/formal</span>
+                            </code>
+                        </td>
+                        <td colspan="1">
+                            <p>
+                            string</p>
+                        </td>
+                        <td colspan="1">
+                        </td>
+                        <td colspan="1">
+                        </td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>
+                            None</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/tests/examples/basic-include/conf.py
+++ b/tests/examples/basic-include/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'
+extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-include/index.rst
+++ b/tests/examples/basic-include/index.rst
@@ -1,0 +1,2 @@
+.. jsonschema:: subdir/test.json
+   :include: id,name/formal

--- a/tests/examples/basic-include/subdir/test.json
+++ b/tests/examples/basic-include/subdir/test.json
@@ -1,0 +1,22 @@
+{
+   "type": "object",
+   "properties": {
+      "id": {
+         "type": "string"
+      },
+      "identifier": {
+         "type": "string"
+      },
+      "name": {
+         "type": "object",
+         "properties": {
+            "formal": {
+               "type": "string"
+            },
+            "informal": {
+               "type": "string"
+            }
+         }
+      }
+   }
+}

--- a/tests/examples/basic-md.pot
+++ b/tests/examples/basic-md.pot
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 
-# This file is distributed under the same license as the Python package.
+# This file is distributed under the same license as the Test package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Python \n"
+"Project-Id-Version: Test \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/tests/examples/basic-md/conf.py
+++ b/tests/examples/basic-md/conf.py
@@ -1,2 +1,3 @@
 master_doc = 'index'
 extensions = ['myst_parser', 'sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic.pot
+++ b/tests/examples/basic.pot
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 
-# This file is distributed under the same license as the Python package.
+# This file is distributed under the same license as the Test package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Python \n"
+"Project-Id-Version: Test \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/tests/examples/basic/conf.py
+++ b/tests/examples/basic/conf.py
@@ -1,2 +1,3 @@
 master_doc = 'index'
 extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -71,3 +71,8 @@ def test_basic_remotejson(app, status, warning):
 @pytest.mark.sphinx(buildername='gettext', srcdir=path('basic-md'), freshenv=True)
 def test_basic_gettext_myst(app, status, warning):
     assert_build(app, status, warning, 'basic-md', buildername='gettext')
+
+
+@pytest.mark.sphinx(buildername='html', srcdir=path('basic-include'), freshenv=True)
+def test_basic_include(app, status, warning):
+    assert_build(app, status, warning, 'basic-include')


### PR DESCRIPTION
The old logic meant that properties beginning with names specified in the `include` and `collapse` options would also be included or collapsed.

For example, given the following schema and directive, both `id` and `identifier` would be included in the output when only `id` is specified in the `include` option:

**Schema**

```json
{
   "properties": {
      "id": {},
      "identifier": {}
   }
}
```

**Directive**

```
.. jsonschema:: schema.json
   :include: id
```

**Output on `main` branch:**

![image](https://github.com/user-attachments/assets/661126e0-1726-4190-9407-cfd2c7d1498a)

**Output on this branch:**

![image](https://github.com/user-attachments/assets/c7d4effa-901d-4921-aea6-ef80a91a32de)
