### PR TITLE
Drop older myst-parser and add Python 3.13 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [  '3.9', '3.10', '3.11', '3.12' ]
-        # Removed testing of myst-parser-version<0.18.0
-        myst-parser-version: [ '>=0.18.0,<0.19', '>=0.19.0,<1.0', '>=1.0.0,<2', '>=2.0.0,<3', '>=3.0.0,<4', '>=4,<5' ]
+        python-version: [  '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        # If you change myst-parser-version versions change the requirment constraints in setup.py too!
+        myst-parser-version: [ '>=0.19.0,<1.0', '>=1.0.0,<2', '>=2.0.0,<3', '>=3.0.0,<4', '>=4,<5' ]
         jsonref-version: [">1"]
         include:
           # jsonref 1.0 has a backwards incompatible change - make sure we test just once with an older version of jsonref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Dropped support for Python 3.8, as this is end of life
+- myst-parser-version<0.19.0 removed from test matrix, as too old and dependency issues with Python 3.13
 
 ## [0.7.1] - 2024-11-25
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'docutils',
         'jsonref',
         'jsonpointer',
-        'myst-parser',
+        'myst-parser>=0.19.0',
         'referencing',
         'jscc',
     ],


### PR DESCRIPTION
Older myst-parser won't work as it needs an old version of Sphinx.
Python 3.13 drops the imghdr library and it all goes wrong

Also set constraint in setup.py