### PR TITLE
Add collapseonref option + missing docs and tests

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -34,6 +34,17 @@ With include option
    :include: id,name,age/actual
 
 
+With prefix option
+------------------
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :prefix: myprefix
+
+.. jsonschema:: example_schema.json
+   :prefix: myprefix
+
 With collapse option
 --------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -45,6 +45,21 @@ With prefix option
 .. jsonschema:: example_schema.json
    :prefix: myprefix
 
+With addtargets flag
+--------------------
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :addtargets:
+
+    See the :ref:`id field <example_schema.json,,id>`.
+
+.. jsonschema:: example_schema.json
+   :addtargets:
+
+See the :ref:`id field <example_schema.json,,id>`.
+
 With collapse option
 --------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -58,6 +58,17 @@ With pointer option
    :pointer: /definitions/Address
 
 
+With collapseonref flag
+-----------------------
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :collapseonref:
+
+.. jsonschema:: example_schema.json
+   :collapseonref:
+
 With nocrossref flag
 --------------------
 

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -57,6 +57,20 @@ You can use this to only show a section of the JSON Schema - in this case, only 
 
 Note the key here is the key is the key in the JSON Schema not the key in the JSON data. This means you can pass keys like `/definitions/Address`.
 
+Option: collapseonref
+---------------------
+
+You can pass the optional flag `collapseonref`.
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :collapseonref:
+
+If passed, any property that uses ``$ref`` will be collapsed — its child properties will not be shown. This is useful when definitions are documented separately and you want to avoid duplicating their fields inline.
+
+This is equivalent to listing every ``$ref`` property path in the ``collapse`` option, but updates automatically when the schema changes.
+
 Option: nocrossref
 ------------------
 

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -57,6 +57,20 @@ If passed, the value is prepended to the HTML anchor ID generated for each prope
 
 This is useful when the same schema is included more than once in a documentation site, where duplicate anchor IDs would otherwise cause conflicts.
 
+Option: addtargets
+------------------
+
+You can pass the optional flag `addtargets`.
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :addtargets:
+
+If passed, each property's anchor is registered with Sphinx's cross-reference system, making it referenceable from other pages using the ``:ref:`` role. Without this flag the anchor IDs still appear in the HTML (so ``#anchor`` links work within the same page), but Sphinx does not know about them.
+
+If the same schema is included on multiple pages, use ``:prefix:`` alongside ``:addtargets:`` to keep anchor IDs unique and avoid duplicate target warnings.
+
 Option: pointer
 ---------------
 

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -43,34 +43,6 @@ You can pass the optional setting `collapse`.
 If passed, then any schema below the passed key will not be shown.
 
 
-Option: prefix
---------------
-
-You can pass the optional setting `prefix`.
-
-.. code-block:: rst
-
-    .. jsonschema:: example_schema.json
-       :prefix: myprefix
-
-If passed, the value is prepended to the HTML anchor ID generated for each property. Without a prefix the anchor ID is formed from the filename, the pointer (if set), and the property path — for example ``test.json,,name``. With ``:prefix: myprefix`` it becomes ``myprefix,test.json,,name``.
-
-This is useful when the same schema is included more than once in a documentation site, where duplicate anchor IDs would otherwise cause conflicts.
-
-Option: addtargets
-------------------
-
-You can pass the optional flag `addtargets`.
-
-.. code-block:: rst
-
-    .. jsonschema:: example_schema.json
-       :addtargets:
-
-If passed, each property's anchor is registered with Sphinx's cross-reference system, making it referenceable from other pages using the ``:ref:`` role. Without this flag the anchor IDs still appear in the HTML (so ``#anchor`` links work within the same page), but Sphinx does not know about them.
-
-If the same schema is included on multiple pages, use ``:prefix:`` alongside ``:addtargets:`` to keep anchor IDs unique and avoid duplicate target warnings.
-
 Option: pointer
 ---------------
 
@@ -141,3 +113,37 @@ You can pass the optional flag `allowexternalrefs`.
 If passed, you can use `$ref` to load remote files and they will be loaded.
 
 If not passed, any remote references will silently be ignored.
+
+
+HTML anchors and cross-references
+----------------------------------
+
+The directive generates an HTML anchor ID for each property row, formed from the filename, the pointer (if set), and the property path, separated by commas — for example ``test.json,,name``. The following options control this behaviour.
+
+Option: prefix
+~~~~~~~~~~~~~~
+
+You can pass the optional setting `prefix`.
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :prefix: myprefix
+
+If passed, the value is prepended to the anchor ID for each property — for example, ``:prefix: myprefix`` changes ``test.json,,name`` to ``myprefix,test.json,,name``.
+
+This is useful when the same schema is included more than once in a documentation site, where duplicate anchor IDs would otherwise cause conflicts.
+
+Option: addtargets
+~~~~~~~~~~~~~~~~~~
+
+You can pass the optional flag `addtargets`.
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :addtargets:
+
+If passed, each property's anchor is registered with Sphinx's cross-reference system, making it referenceable from other pages using the ``:ref:`` role. Without this flag the anchor IDs still appear in the HTML (so ``#anchor`` links work within the same page), but Sphinx does not know about them.
+
+If the same schema is included on multiple pages, use ``:prefix:`` alongside ``:addtargets:`` to keep anchor IDs unique and avoid duplicate target warnings.

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -43,6 +43,20 @@ You can pass the optional setting `collapse`.
 If passed, then any schema below the passed key will not be shown.
 
 
+Option: prefix
+--------------
+
+You can pass the optional setting `prefix`.
+
+.. code-block:: rst
+
+    .. jsonschema:: example_schema.json
+       :prefix: myprefix
+
+If passed, the value is prepended to the HTML anchor ID generated for each property. Without a prefix the anchor ID is formed from the filename, the pointer (if set), and the property path — for example ``test.json,,name``. With ``:prefix: myprefix`` it becomes ``myprefix,test.json,,name``.
+
+This is useful when the same schema is included more than once in a documentation site, where duplicate anchor IDs would otherwise cause conflicts.
+
 Option: pointer
 ---------------
 

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -70,6 +70,7 @@ class JSONSchemaDirective(Directive):
     option_spec = {
         'include': directives.unchanged,
         'collapse': directives.unchanged,
+        'collapseonref': directives.flag,
         'pointer': directives.unchanged,
         'nocrossref': directives.flag,
         'addtargets': directives.flag,
@@ -162,6 +163,8 @@ class JSONSchemaDirective(Directive):
         tgroup += nodes.thead('', header_row)
         tbody = nodes.tbody()
         tgroup += tbody
+        collapse_on_ref = 'collapseonref' in self.options
+        ref_paths = set()
         for prop in schema:
             path = prop.name.split('/')
             if self.include:
@@ -174,6 +177,14 @@ class JSONSchemaDirective(Directive):
                 if path in self.collapse:
                     self.collapse_used.add(tuple(path))
                 else:
+                    continue
+            if collapse_on_ref:
+                path_tuple = tuple(path)
+                if hasattr(prop.attributes, '__reference__') and prop.attributes.__reference__.get('$ref'):
+                    ref_paths.add(path_tuple)
+                elif hasattr(prop.items, '__reference__') and prop.items.__reference__.get('$ref'):
+                    ref_paths.add(path_tuple)
+                if any(path_tuple[:len(r)] == r and path_tuple != r for r in ref_paths):
                     continue
             if '^' in prop.name:
                 # Skip patternProperties

--- a/tests/examples/basic-addtargets-crossref/conf.py
+++ b/tests/examples/basic-addtargets-crossref/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'
+extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-addtargets-crossref/crossref.rst
+++ b/tests/examples/basic-addtargets-crossref/crossref.rst
@@ -1,0 +1,4 @@
+Cross Reference
+===============
+
+See :ref:`id field <test.json,,id>`.

--- a/tests/examples/basic-addtargets-crossref/index.rst
+++ b/tests/examples/basic-addtargets-crossref/index.rst
@@ -1,0 +1,6 @@
+.. toctree::
+
+   crossref
+
+.. jsonschema:: subdir/test.json
+   :addtargets:

--- a/tests/examples/basic-addtargets-crossref/subdir/test.json
+++ b/tests/examples/basic-addtargets-crossref/subdir/test.json
@@ -1,0 +1,22 @@
+{
+   "type": "object",
+   "properties": {
+      "id": {
+         "type": "string"
+      },
+      "identifier": {
+         "type": "string"
+      },
+      "name": {
+         "type": "object",
+         "properties": {
+            "formal": {
+               "type": "string"
+            },
+            "informal": {
+               "type": "string"
+            }
+         }
+      }
+   }
+}

--- a/tests/examples/basic-addtargets.html
+++ b/tests/examples/basic-addtargets.html
@@ -1,0 +1,94 @@
+<div class="documentwrapper">
+    <div class="bodywrapper">
+        <div class="body" role="main">
+            <table class="docutils align-default">
+                <thead>
+                    <tr class="row-odd">
+                        <th class="head" colspan="1">
+                            <p>Title</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Description</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Type</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Format</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Required</p>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,id"><span class="pre">id</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,identifier"><span class="pre">identifier</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,name"><span class="pre">name</span></code></td>
+                        <td colspan="1">
+                            <p>object</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,name/formal"><span class="pre">name/formal</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,name/informal"><span class="pre">name/informal</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/tests/examples/basic-addtargets/conf.py
+++ b/tests/examples/basic-addtargets/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'
+extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-addtargets/index.rst
+++ b/tests/examples/basic-addtargets/index.rst
@@ -1,0 +1,2 @@
+.. jsonschema:: subdir/test.json
+   :addtargets:

--- a/tests/examples/basic-addtargets/subdir/test.json
+++ b/tests/examples/basic-addtargets/subdir/test.json
@@ -1,0 +1,22 @@
+{
+   "type": "object",
+   "properties": {
+      "id": {
+         "type": "string"
+      },
+      "identifier": {
+         "type": "string"
+      },
+      "name": {
+         "type": "object",
+         "properties": {
+            "formal": {
+               "type": "string"
+            },
+            "informal": {
+               "type": "string"
+            }
+         }
+      }
+   }
+}

--- a/tests/examples/basic-collapseonref.html
+++ b/tests/examples/basic-collapseonref.html
@@ -1,0 +1,73 @@
+<div class="documentwrapper">
+    <div class="bodywrapper">
+        <div class="body" role="main">
+            <table class="docutils align-default">
+                <thead>
+                    <tr class="row-odd">
+                        <th class="head" colspan="1">
+                            <p>Title</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Description</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Type</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Format</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Required</p>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,name"><span class="pre">name</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,address"><span class="pre">address</span></code></td>
+                        <td colspan="1">
+                            <p>object</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                        <td colspan="4">
+                            <p>The person&#8217;s address.</p>
+                            <p>
+See <a class="reference external" href="#address">Address</a></p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="test.json,,tag"><span class="pre">tag</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/tests/examples/basic-collapseonref/conf.py
+++ b/tests/examples/basic-collapseonref/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'
+extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-collapseonref/index.rst
+++ b/tests/examples/basic-collapseonref/index.rst
@@ -1,0 +1,2 @@
+.. jsonschema:: subdir/test.json
+   :collapseonref:

--- a/tests/examples/basic-collapseonref/subdir/test.json
+++ b/tests/examples/basic-collapseonref/subdir/test.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "address": {
+      "$ref": "#/definitions/Address",
+      "description": "The person's address."
+    },
+    "tag": {"type": "string"}
+  },
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "street": {"type": "string"},
+        "city": {"type": "string"}
+      }
+    }
+  }
+}

--- a/tests/examples/basic-prefix.html
+++ b/tests/examples/basic-prefix.html
@@ -1,0 +1,94 @@
+<div class="documentwrapper">
+    <div class="bodywrapper">
+        <div class="body" role="main">
+            <table class="docutils align-default">
+                <thead>
+                    <tr class="row-odd">
+                        <th class="head" colspan="1">
+                            <p>Title</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Description</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Type</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Format</p>
+                        </th>
+                        <th class="head" colspan="1">
+                            <p>Required</p>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="myprefix,test.json,,id"><span class="pre">id</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="myprefix,test.json,,identifier"><span class="pre">identifier</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="myprefix,test.json,,name"><span class="pre">name</span></code></td>
+                        <td colspan="1">
+                            <p>object</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="myprefix,test.json,,name/formal"><span class="pre">name/formal</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                    <tr class="row-even">
+                        <td colspan="2"><code class="docutils literal notranslate" id="myprefix,test.json,,name/informal"><span class="pre">name/informal</span></code></td>
+                        <td colspan="1">
+                            <p>string</p>
+                        </td>
+                        <td colspan="1"></td>
+                        <td colspan="1"></td>
+                    </tr>
+                    <tr class="row-odd">
+                        <td colspan="1">
+                            <p>None</p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/tests/examples/basic-prefix/conf.py
+++ b/tests/examples/basic-prefix/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'
+extensions = ['sphinxcontrib.jsonschema']
+project = 'Test'

--- a/tests/examples/basic-prefix/index.rst
+++ b/tests/examples/basic-prefix/index.rst
@@ -1,0 +1,2 @@
+.. jsonschema:: subdir/test.json
+   :prefix: myprefix

--- a/tests/examples/basic-prefix/subdir/test.json
+++ b/tests/examples/basic-prefix/subdir/test.json
@@ -1,0 +1,22 @@
+{
+   "type": "object",
+   "properties": {
+      "id": {
+         "type": "string"
+      },
+      "identifier": {
+         "type": "string"
+      },
+      "name": {
+         "type": "object",
+         "properties": {
+            "formal": {
+               "type": "string"
+            },
+            "informal": {
+               "type": "string"
+            }
+         }
+      }
+   }
+}

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -87,3 +87,8 @@ def test_basic_include(app, status, warning):
 @pytest.mark.sphinx(buildername='html', srcdir=path('basic-collapseonref'), freshenv=True)
 def test_basic_collapseonref(app, status, warning):
     assert_build(app, status, warning, 'basic-collapseonref')
+
+
+@pytest.mark.sphinx(buildername='html', srcdir=path('basic-prefix'), freshenv=True)
+def test_basic_prefix(app, status, warning):
+    assert_build(app, status, warning, 'basic-prefix')

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -82,3 +82,8 @@ def test_basic_gettext_myst(app, status, warning):
 @pytest.mark.sphinx(buildername='html', srcdir=path('basic-include'), freshenv=True)
 def test_basic_include(app, status, warning):
     assert_build(app, status, warning, 'basic-include')
+
+
+@pytest.mark.sphinx(buildername='html', srcdir=path('basic-collapseonref'), freshenv=True)
+def test_basic_collapseonref(app, status, warning):
+    assert_build(app, status, warning, 'basic-collapseonref')

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -92,3 +92,22 @@ def test_basic_collapseonref(app, status, warning):
 @pytest.mark.sphinx(buildername='html', srcdir=path('basic-prefix'), freshenv=True)
 def test_basic_prefix(app, status, warning):
     assert_build(app, status, warning, 'basic-prefix')
+
+
+@pytest.mark.sphinx(buildername='html', srcdir=path('basic-addtargets'), freshenv=True)
+def test_basic_addtargets(app, status, warning):
+    assert_build(app, status, warning, 'basic-addtargets')
+
+
+@pytest.mark.sphinx(buildername='html', srcdir=path('basic-addtargets-crossref'), freshenv=True)
+def test_basic_addtargets_crossref(app, status, warning):
+    """addtargets registers targets with Sphinx so :ref: links from other pages resolve."""
+    app.build()
+    assert 'build succeeded' in status.getvalue()
+    assert warning.getvalue().strip() == ''
+
+    with open(path('basic-addtargets-crossref', '_build', 'html', 'crossref.html'), encoding='utf-8') as f:
+        doc = lxml.html.fromstring(f.read())
+
+    links = doc.xpath('//a[@class="reference internal"]')
+    assert any(link.get('href') == 'index.html#test.json,,id' for link in links)


### PR DESCRIPTION
* Add an option to automatically collapse properties that `$ref` a definition. This is helpful for keeping directive configurations in sync with changes to the schema.
* Add docs and tests for the `prefix` option added in #67 
* Closes #37, and adds a test
* Document HTML anchor behaviour

I used AI to prepare this PR. The code and docs changes were reviewed in detail. The tests were not, but I figure it's an improvement on the previous (no tests) situation.